### PR TITLE
the one that removes and moves content

### DIFF
--- a/content/A-Z-styleguide.md
+++ b/content/A-Z-styleguide.md
@@ -27,7 +27,9 @@ See: [roles](#roles-job-titles)
 ### abbreviations
 The first time you use an abbreviation or acronym, explain it in full with the acronym following in parentheses. Then refer to it by capitalised initials.
 
-For example:  ‘You may need to pay an article processing charge (APC). The APC for this article is…’
+For example:
+<br>
+‘You may need to pay an article processing charge (APC). The APC for this article is…’
 
 Don’t  use full stops in abbreviations: APC not A.P.C.
 ## B
@@ -63,7 +65,9 @@ You don’t need full stops or semicolons in your list.
 ### capitalisation
 Use sentence case for headings.
 
-Example: ‘Your account details’ not ‘Your Account Details’.
+Example:
+<br>
+‘Your account details’ not ‘Your Account Details’.
 
 Only capitalise words at the front of sentences (sentence case) and proper nouns.
 
@@ -90,9 +94,8 @@ Licence = British English noun
 License = British English verb.
 
 Examples:
-
+<br>
 - The CC BY licence  is the default licence for all Palgrave Macmillan and SpringerOpen books and chapters.
-
 - For more information on OA licensing options in Springer Nature books and chapters see our [book policies page](https://www.springernature.com/gp/open-research/policies/book-policies).
 
 ### chapter processing charge (CPC)
@@ -104,7 +107,7 @@ Checkout can be used but only as a noun or adjective.
 Use ‘check  out’  for the verb form. Don’t hyphenate.
 
 Examples:
-
+<br>
 - Creating an account will make it faster to check out next time.
 - Use your saved details for a faster checkout experience.
 - Go to checkout.
@@ -121,7 +124,7 @@ Lower case.
 Using contractions can make your writing sound more human and personal. (Link to our SN brand voice and tone).
 
 Examples:
-
+<br>
 - you’re
 - we’ll
 - it’s (it is)
@@ -129,7 +132,7 @@ Examples:
 Do not use negative or conditional contractions as they are harder to understand for people who do not speak English as a first language.
 
 Examples not to use:
-
+<br>
 - wouldn’t
 - don’t
 - haven’t
@@ -161,14 +164,15 @@ Our most common currencies used are:
 Here is a [list of all currency codes](https://www.iban.com/currency-codes).
 
 Example:
-
+<br>
 You can only pay in United States Dollars (USD). The cost is 54.67 USD.
 
 Use a decimal point as a separator for dollars and cents. And commas as a separator of threes.
 
 Example:
-
+<br>
 1,234,567.89 USD
+
 ## D
 ### dates
 Write dates in full to avoid ambiguity.
@@ -183,7 +187,6 @@ Stands for digital object identifier.
 Use DOI in its abbreviated form in interface text.
 
 Example:
-
 DOI: 10.3103/S0967091211120151
 
 ### double-anonymous
@@ -211,7 +214,7 @@ See [roles](#roles-job-titles)
 Lower case, for generic roles or the board itself. Upper case if referring to a specific board member.
 
 Examples:
-
+<br>
 - John is on the editorial board for Journal x.
 - John Brown, Editorial Board Member, Journal x
 
@@ -221,7 +224,7 @@ Latin abbreviations can sometimes be misunderstood or mispronounced by screen re
 Do not use ‘etc’. Use ‘for example’ or ‘such as’ or ‘like’ or ‘including’ – whichever works best in the specific context.
 
 Example label on a UI form field:
-
+<br>
 - Funding source (for example, university or institutional funding)
 
 ### emails
@@ -247,7 +250,7 @@ Avoid for UX microcopy or functional text. Exclamation marks can dramatically im
 Capitalised. Not ‘.PDF’.
 
 Examples:
-
+<br>
 Upload a ZIP file.
 
 We accept manuscripts in the following formats: DOC, PDF, ZIP.
@@ -268,12 +271,12 @@ Use ‘to’ instead of a hyphen in date or time ranges. This makes it easier fo
 Avoid idioms as they are harder to understand and translate.
 
 For example, instead of:
-
-- ‘We will take steps to…’
-
+<br>
+'We will take steps to…’
+<br>
 Write:
-
-- ‘We will begin to…’
+<br>
+‘We will begin to…’
 
 ### impact factor
 Lower case.
@@ -291,18 +294,18 @@ Note capitalisation. File format commonly used in scientific disciplines includi
 Always use plain language instead of complex legal language.
 
 For example, instead of:
-
+<br>
 “I understand that for digital products, Springer Nature may start the performance of the contract before the end of the withdrawal period and I acknowledge that I thereby lose my right of withdrawal”.
-
+<br>
 Write:
-
+<br>
 “If you have bought a digital product, for example an eBook, you agree to waive your right to cancel after you select 'buy now'. You will be able to access the item immediately  after purchase.”
 
 ### licence / license
 In British English, licence is the noun and license is the verb.
 
 Examples:
-
+<br>
 - A Springer Nature licence is available to academic institutions.
 - How to license our journal articles.
 
@@ -319,7 +322,7 @@ They’re not accessible as they  can’t be understood out of context.
 Make the link text specific and use active language.
 
 Example:
-
+<br>
 Read more about [open research](https://www.springernature.com/gp/open-research).
 
 ### linking from emails
@@ -328,7 +331,7 @@ For rich text emails, follow guidance for [link text](#link-text).
 For plain text emails, introduce the link with specific and active language.
 
 Example:
-
+<br>
 Continue with publishing your article: <https://publishing-rights.springernature.com/workflows/1234>
 
 ### log in, login
@@ -337,7 +340,7 @@ Login can be used but only as a noun or adjective.
 Use ‘log in’, ‘log out’ for the verb forms. Don’t hyphenate.
 
 Examples:
-
+<br>
 - You need to log in to update your address.
 - If you have forgotten your login details - contact us.
 
@@ -351,7 +354,7 @@ See: [submission](#submission)
 Within emails, titles should be displayed within single quotes.
 
 Example:
-
+<br>
 We're delighted that your article has been accepted for publication:
 
 'The effects of exercise training on hypertensive older adults'.
@@ -374,7 +377,9 @@ Write numbers in numerals (including 1 to 9), unless they’re part of a common 
 ### open access, open data, open science
 Lower case. Unless it’s part of a proper name.
 
-Example: The Open Access Support Centre was set up to help people understand their options for publishing open access.
+Example:
+<br>
+The Open Access Support Centre was set up to help people understand their options for publishing open access.
 
 ### OA
 Abbreviation for open access.
@@ -383,7 +388,9 @@ Abbreviation for open access.
 ### PDF
 All capitals. Not ‘.PDF’
 
-Example: Upload a PDF file.
+Example:
+<br>
+Upload a PDF file.
 
 ### peer review
 Lower case. No hyphen.
@@ -413,7 +420,7 @@ Write:
 Lower case. One word, no hyphen.
 
 Example:
-
+<br>
 Research Square provides a free preprinting service to all authors.
 
 ### pronouns
@@ -436,14 +443,14 @@ Examples:
 Don’t use gendered pronouns, for example: he, him, she, her. If you must use a pronoun, use ‘they/them/their’ instead.
 
 Example:
-
-- Contact the editor if you need help. They can help with any issues.
+<br>
+Contact the editor if you need help. They can help with any issues.
 
 If possible, try to rephrase your sentence instead.
 
 Example:
-
-- If you need help with any issues, contact the editor.
+<br>
+If you need help with any issues, contact the editor.
 ## Q
 ### quality check
 Lower case. This may change to ‘technical check’ as the preferred term.
@@ -468,7 +475,9 @@ Use double quotes in body text for direct quotations.
 ### roles, job titles
 Specific job titles are capitalised, generic roles aren’t.
 
-Example: Elizabeth is Editor-in-Chief of journal x. We have many editors-in-chief.
+Example:
+<br>
+Elizabeth is Editor-in-Chief of journal x. We have many editors-in-chief.
 ## S
 ### salutation (emails)
 Use: Dear Title FirstName Surname
@@ -530,7 +539,7 @@ Use the 24-hour clock together with Coordinated Universal Time (UTC) if you are 
 Use a colon (:) between the numbers.
 
 Examples:
-
+<br>
 - We received your submission at 13:24 (UTC).
 - Our system will be down for maintenance between 23:59 and 03:00 (UTC)
 

--- a/content/A-Z-styleguide.md
+++ b/content/A-Z-styleguide.md
@@ -1,1 +1,596 @@
-"A-Z Styleguide" content goes here.
+# A-Z writing style guide
+
+Purpose of this document: to support a consistent customer experience by defining spelling and grammar conventions used across our Springer Nature products and services.
+
+Intended audience: anyone writing or testing user-facing copy in SND (including designers, product managers, QA, BAs, developers, copywriters, content designers).
+
+## How to add to this guide:
+
+
+## A
+### alt text on images
+Follow the guidance on the [W3C accessibility website](https://www.w3.org/WAI/tutorials/images/decision-tree/).
+
+### article
+Use ‘article’ to refer to the final accepted manuscript (of article format), ready for publication.
+
+Do not use ‘paper’.
+
+### article processing charge
+Lower case, no hyphen.
+
+### author
+Lower case.
+
+See: [roles](#roles-job-titles)
+
+### abbreviations
+The first time you use an abbreviation or acronym, explain it in full with the acronym following in parentheses. Then refer to it by capitalised initials.
+
+For example:  ‘You may need to pay an article processing charge (APC). The APC for this article is…’
+
+Don’t  use full stops in abbreviations: APC not A.P.C.
+## B
+### basket
+E-commerce. Ideally, localise to domain.
+
+Cart = American English
+
+Basket = British English.
+
+See: [cart](#cart)
+
+### book processing charge
+Lower case. No hyphen.
+
+### British or American English
+We  write in British English for all of our digital products and services (except where the user base is solely in the US).
+
+To  make it easier to create interfaces that work internationally, try to avoid [words which have alternative American spellings](https://www.oxfordinternationalenglish.com/differences-in-british-and-american-spelling/) where possible.
+
+This doesn’t apply to marketing or corporate communications copy where the team may be writing for a specific audience segment.
+
+### bullet points
+You can use bullets to make text easier to read. Make sure that:
+
+- you introduce the list with a lead-in line (for example, ‘Make sure that:’)
+- the bullet text makes sense as a continuation from the lead-in line
+- you use lower case at the start of the bullet
+- you don’t use more than one sentence per bullet - use commas or a dash to expand if you need to
+
+You don’t need full stops or semicolons in your list.
+
+### capitalisation
+Use sentence case for headings.
+
+Example: ‘Your account details’ not ‘Your Account Details’.
+
+Only capitalise words at the front of sentences (sentence case) and proper nouns.
+
+See: capitalisation for [roles](#roles-job-titles)
+
+### cart
+E-commerce. Localise to domain if possible.
+
+Cart = American English
+
+Basket = British English.
+
+See: basket
+### CC BY
+Type of Creative Commons licence. All capitals, no hyphen.
+
+A hyphen is used only if there’s a clause relating to the licence, for example a non-commercial open licence would be  ‘CC BY-NC’.
+
+### Creative Commons attribution licence (CC BY)
+Upper case on Creative Commons. Lower on attribution licence.
+
+Licence = British English noun
+
+License = British English verb.
+
+Examples:
+
+- The CC BY licence  is the default licence for all Palgrave Macmillan and SpringerOpen books and chapters.
+
+- For more information on OA licensing options in Springer Nature books and chapters see our [book policies page](https://www.springernature.com/gp/open-research/policies/book-policies).
+
+### chapter processing charge (CPC)
+Lower case, no hyphen.
+
+### check out, checkout
+Checkout can be used but only as a noun or adjective.
+
+Use ‘check  out’  for the verb form. Don’t hyphenate.
+
+Examples:
+
+- Creating an account will make it faster to check out next time.
+- Use your saved details for a faster checkout experience.
+- Go to checkout.
+
+### click here
+Do not use.
+
+See: [link text](#link-text)
+
+### collection (article collection)
+Lower case.
+
+### contractions
+Using contractions can make your writing sound more human and personal. (Link to our SN brand voice and tone).
+
+Examples:
+
+- you’re
+- we’ll
+- it’s (it is)
+
+Do not use negative or conditional contractions as they are harder to understand for people who do not speak English as a first language.
+
+Examples not to use:
+
+- wouldn’t
+- don’t
+- haven’t
+
+
+### corresponding author
+
+Lower case.
+
+### country
+Do not use  ‘country’ as a label for a drop-down list of locations.
+
+Some countries are not internationally recognised. Some teams may also be using this list to identify sanctioned countries or territories.
+
+Use ‘Country / region’ instead.
+### currency
+Write currency codes following an amount of money. If you can, introduce the acronym in the text before writing out the amount of money.
+
+See: [abbreviations](#abbreviations)
+
+Do not use currency symbols. Symbols can be hard to scan, and read – especially for those with a learning difficulty.
+
+Our most common currencies used are:
+
+- United States Dollar (USD)
+- Euros (EUR)
+- Great British Pounds (GBP)
+
+Here is a [list of all currency codes](https://www.iban.com/currency-codes).
+
+Example:
+
+You can only pay in United States Dollars (USD). The cost is 54.67 USD.
+
+Use a decimal point as a separator for dollars and cents. And commas as a separator of threes.
+
+Example:
+
+1,234,567.89 USD
+## D
+### dates
+Write dates in full to avoid ambiguity.
+
+Use the format: 28 September 2022
+
+For tables, or where space is an issue, use the shortened form: Jan, Feb, Mar etc.
+
+### DOI
+Stands for digital object identifier.
+
+Use DOI in its abbreviated form in interface text.
+
+Example:
+
+DOI: 10.3103/S0967091211120151
+
+### double-anonymous
+In reference to the peer review process. Lower case, hyphenated.
+
+See: [single-anonymous](#single-anonymous)
+
+### double-blind, double blind
+We no longer use ‘double-blind’ or ‘double blind’ in our systems or in messages to our customers when referring to  the review process.
+
+Use ‘double-anonymous’ instead.
+
+See: [double-anonymous](#double-anonymous)
+
+### Dr
+No full stop is necessary.
+## E
+### eBook
+Not ‘Ebook’, ‘EBook’, ‘ebook’ or ‘EBOOK’.
+
+### editor, editor-in-chief, handling editor
+See [roles](#roles-job-titles)
+
+### editorial board, editorial board members
+Lower case, for generic roles or the board itself. Upper case if referring to a specific board member.
+
+Examples:
+
+- John is on the editorial board for Journal x.
+- John Brown, Editorial Board Member, Journal x
+
+### eg, etc and ie
+Latin abbreviations can sometimes be misunderstood or mispronounced by screen reading software. Instead of using  ‘eg’ or ‘ie’, write  ‘for example’ and ‘that is’  in full.
+
+Do not use ‘etc’. Use ‘for example’ or ‘such as’ or ‘like’ or ‘including’ – whichever works best in the specific context.
+
+Example label on a UI form field:
+
+- Funding source (for example, university or institutional funding)
+
+### emails
+Follow the guidelines for plain language.
+
+Emails are often read on mobile devices so brevity and a clear focus on the action you want the user to take are critical. Use  structure with headings or bullets to allow for quick scanning.
+
+Pay particular attention to your subject line and front-load the important words (for example, the journal title).
+
+See: [salutation (emails)](#salutation-emails), [signature (emails)](#signature-for-system-emails), [linking from emails](#linking-from-emails)
+
+### EPUB
+File format for eBooks. Capitalised.
+
+Example (button text): Download EPUB
+
+### exclamation marks
+Avoid for UX microcopy or functional text. Exclamation marks can dramatically impact the tone of what you’re saying, only use them where appropriate for the user experience.
+
+
+## F
+### file names: PDF, DOC, ZIP
+Capitalised. Not ‘.PDF’.
+
+Examples:
+
+Upload a ZIP file.
+
+We accept manuscripts in the following formats: DOC, PDF, ZIP.
+## G
+### gold open access, green open access
+Lower case.
+
+## H
+### hyphens
+Only use a hyphen if a word is confusing without it.
+
+“Hyphens slow online comprehension as words with hyphens take longer to scan. They can make the reader need to stop to unpick meaning.” ([Readability Guidelines](https://readabilityguidelines.co.uk/grammar-points/hyphens-and-dashes/#:~:text=Hyphens%20slow%20online%20comprehension%20as,is%20that%20they%20avoid%20ambiguity.))
+
+Use ‘to’ instead of a hyphen in date or time ranges. This makes it easier for screen readers.
+
+## I
+### idioms
+Avoid idioms as they are harder to understand and translate.
+
+For example, instead of:
+
+- ‘We will take steps to…’
+
+Write:
+
+- ‘We will begin to…’
+
+### impact factor
+Lower case.
+
+## J
+### job titles
+See: [roles](#roles-job-titles)
+
+## K
+## L
+### LaTeX
+Note capitalisation. File format commonly used in scientific disciplines including  maths, physics and astronomy.
+
+### legal text
+Always use plain language instead of complex legal language.
+
+For example, instead of:
+
+“I understand that for digital products, Springer Nature may start the performance of the contract before the end of the withdrawal period and I acknowledge that I thereby lose my right of withdrawal”.
+
+Write:
+
+“If you have bought a digital product, for example an eBook, you agree to waive your right to cancel after you select 'buy now'. You will be able to access the item immediately  after purchase.”
+
+### licence / license
+In British English, licence is the noun and license is the verb.
+
+Examples:
+
+- A Springer Nature licence is available to academic institutions.
+- How to license our journal articles.
+
+### link text
+Do not use any of the following (or similar) as link text:
+
+- ‘click here’
+- ‘here’
+- ‘read more’
+- ‘find out more’
+
+They’re not accessible as they  can’t be understood out of context.
+
+Make the link text specific and use active language.
+
+Example:
+
+Read more about [open research](https://www.springernature.com/gp/open-research).
+
+### linking from emails
+For rich text emails, follow guidance for [link text](#link-text).
+
+For plain text emails, introduce the link with specific and active language.
+
+Example:
+
+Continue with publishing your article: <https://publishing-rights.springernature.com/workflows/1234>
+
+### log in, login
+Login can be used but only as a noun or adjective.
+
+Use ‘log in’, ‘log out’ for the verb forms. Don’t hyphenate.
+
+Examples:
+
+- You need to log in to update your address.
+- If you have forgotten your login details - contact us.
+
+## M
+### manuscript
+Use ‘manuscript’ to refer to the completed research document  that an author submits to us via Snapp or another editorial system. Don’t use ‘paper’.
+
+See: [submission](#submission)
+
+### manuscript / submission / article title
+Within emails, titles should be displayed within single quotes.
+
+Example:
+
+We're delighted that your article has been accepted for publication:
+
+'The effects of exercise training on hypertensive older adults'.
+
+### MyCopy
+Capital M, capital  C.
+
+## N
+### names (on form fields)
+Don’t use ‘first name’, ‘last name’ for an international audience.
+
+Use:
+
+- ‘Given names’ instead of ‘First name’
+- ‘Family name’ instead of ‘Last name’
+
+### numbers
+Write numbers in numerals (including 1 to 9), unless they’re part of a common expression where numerals would look odd (like ‘one or two of them’).
+## O
+### open access, open data, open science
+Lower case. Unless it’s part of a proper name.
+
+Example: The Open Access Support Centre was set up to help people understand their options for publishing open access.
+
+### OA
+Abbreviation for open access.
+
+## P
+### PDF
+All capitals. Not ‘.PDF’
+
+Example: Upload a PDF file.
+
+### peer review
+Lower case. No hyphen.
+### please
+Use sparingly, and only when necessary - especially in UI. Be mindful of the [voice and tone](#voice-and-tone) you’re using when considering this.
+### positional or directional language
+Do not use. There are accessibility (and device interaction) issues with words such as ‘below’, ‘on the right’, ‘above’.
+
+Examples to avoid:
+
+- Download the report by clicking the box on the right
+- Complete the form below
+- Select from our list of services on the left
+- Scroll down and click the green button
+
+Often directional language is redundant: the design should not need instructions.
+
+Instead of:
+
+‘Select from the options below:’
+
+Write:
+
+‘Select from these options:’
+
+### preprint, preprinting
+Lower case. One word, no hyphen.
+
+Example:
+
+Research Square provides a free preprinting service to all authors.
+
+### pronouns
+Using personal pronouns makes our writing more human and conversational (in line with our brand values). Use ‘we’ and ‘you’ to talk about Springer Nature and the customer.
+
+We don’t label things ‘my’, for example ‘my details’.
+
+Use ‘your details’, ‘your  address’ in headers if you need to.
+
+Exceptions:
+
+- confirmation checkboxes
+- headings phrased as questions
+
+Examples:
+
+- [ ]  I agree to the terms and conditions. I understand you may contact me about my purchase.
+- How do I find my article’s DOI?
+
+Don’t use gendered pronouns, for example: he, him, she, her. If you must use a pronoun, use ‘they/them/their’ instead.
+
+Example:
+
+- Contact the editor if you need help. They can help with any issues.
+
+If possible, try to rephrase your sentence instead.
+
+Example:
+
+- If you need help with any issues, contact the editor.
+## Q
+### quality check
+Lower case. This may change to ‘technical check’ as the preferred term.
+
+### quote marks
+
+**single quotes**
+
+Use single quotes:
+
+- for unusual terms
+- when referring to user actions
+- for manuscript or article names within emails
+
+Example: Go to your profile page and select ‘Editorial dashboard’.
+
+**double quotes**
+
+Use double quotes in body text for direct quotations.
+
+## R
+### roles, job titles
+Specific job titles are capitalised, generic roles aren’t.
+
+Example: Elizabeth is Editor-in-Chief of journal x. We have many editors-in-chief.
+## S
+### salutation (emails)
+Use: Dear Title FirstName Surname
+
+### sign in, sign out, sign up
+Use ‘log in/out’ instead of ‘sign in/out’.
+
+Sign up (meaning ‘register’) is fine.
+
+See [log in](#log-in-login)
+
+### signature (for system emails)
+
+You don’t need to put your team name in system emails.
+
+Use:
+
+Kind regards,
+
+Springer Nature
+
+Where it’s important to the user that the journal is identified,  it should read:
+
+Kind regards,
+
+Journal of Pharmacology
+
+Springer Nature
+
+### single-anonymous
+In reference to the peer review process. Lower case. Hyphen.
+
+Use instead of ‘single-blind’.
+
+### single-blind, single blind
+In reference to the peer review process. Use ‘single-anonymous’.
+
+### Snapp
+Initial capital only. Not ‘SNAPP’, or ‘snapp’.
+
+Short for Springer Nature’s article processing platform.
+
+### softcover
+One word. Use instead of paperback.
+
+### submission
+This refers to all the documents and data an author submits through Snapp. This includes the manuscript, related data files and declarations made in the system.
+
+See: [manuscript](#manuscript)
+## T
+### terms and conditions
+Lower case. Use ‘and’ not ‘&’.
+
+### thank you
+Use sparingly and only when necessary – especially on UI. Be mindful of the [voice and tone](#voice-and-tone) you’re using when considering this.
+### times
+Use the 24-hour clock together with Coordinated Universal Time (UTC) if you are unable to tell which timezone your user is in.
+
+Use a colon (:) between the numbers.
+
+Examples:
+
+- We received your submission at 13:24 (UTC).
+- Our system will be down for maintenance between 23:59 and 03:00 (UTC)
+
+
+As the majority of our users will not be in this timezone, add the ability to convert to a local timezone if possible.
+
+Suggestion to improve  accessibility:
+
+Please apply before 16:00 (UTC). [What’s this in my timezone?](https://www.google.com/search?q=13%3A24+UTC)
+
+### transformative journals
+Lower case.
+
+## U
+## V
+### voice and tone
+Here are the Springer Nature brand attributes that apply to UX writing, with some tips on how to apply them:
+
+- **friendly**
+  - write things as you’d say them out loud (for example: ‘We’ve sent you a security code’ instead of ‘You have been sent a security code’)
+  - use contractions like ‘you’ll’ instead of ‘you will’
+  - say sorry when something has gone wrong  (for example, ‘Sorry, this service is currently unavailable. Try again in a few minutes’)
+- **transparent**
+  - be specific about what will happen and when (for example, ‘We’ll email you within 24 hours’)
+  - make costs clear upfront – there should be no unwelcome surprises
+  - avoid or explain acronyms
+  - use the active voice to make clear who is doing what
+- **simplified**
+  - write short sentences (max 25 words)
+  - choose easy, conversational words over formal ones
+  - avoid idioms that may translate to an international audience
+- **confident**
+  - be direct and remove unnecessary filler words
+
+**Tone**
+
+We want to sound human and empathetic. Using empathy in writing means being sensitive to the user’s context, particularly in stressful moments.
+
+When it comes to error messaging,  payments and transactions, time-based interactions,  clarity always comes first.
+
+## X
+## Y
+## Z
+
+## Sources and references.
+
+- [StoA style guide](https://docs.google.com/document/d/1OGJSIbEQ1qXLnJMXlV15-h0QivUhzEzA/edit) - internal for Snapp only, not maintained
+- [Nature style guide](https://docs.google.com/document/d/1rVIQO_tBjf4VHXYdLUoEfh6cDedv9QvY/edit) - internal, Nature brand
+- [Nature portfolio tone of voice](https://drive.google.com/drive/search?q=tone%20of%20voice) - internal, Nature brand
+- [Readability Guidelines](https://readabilityguidelines.co.uk/) - universal style guide based on research and including accessibility best practice
+- [British Dyslexia Association style guide](https://www2.worc.ac.uk/disabilityanddyslexia/content_images/BDA_Dyslexia_Style_Guide.pdf) - writing for dyslexia and other learning difficulties
+- [Creative Commons](https://creativecommons.org/) - OA terminology
+- [Green or gold routes to open access ](https://www.springernature.com/gp/open-research/about/green-or-gold-routes-to-oa)- OA terminology
+- [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style) - incorporates many plain language recommendations
+- [Neilsen Norman Group UX writing study guide](https://www.nngroup.com/articles/ux-writing-study-guide/) - list of resources for learning about UX writing
+- [Material design](https://material.io/design/communication/writing.html#principles) - time and date variations
+- [IBAN currency codes](https://www.iban.com/currency-codes)
+- [Mailchimp content style guide](https://styleguide.mailchimp.com/) - internationalisation, writing for translation
+- [Global Production’s style guide on HIVE](https://hive.springernature.com/serve/AMIfv95v1k54y-aVlKJFDwMw6Vk7ujhqTzC_gULVciZBNmNxJxVlCVH-B7XMPfKdOHsP0eG-FZuOOunyGjq8DB5__OWnHJUU6uYZV4oxbEH7kunt2fIyykWObgroFcc4-W_yruxauozlYGBE5CnxKFpbwKY68wR3xg/Style-Manual-9.pdf)
+- [The Chicago Manual of Style Online](https://www.chicagomanualofstyle.org/home.html)
+
+
+

--- a/content/A-Z-styleguide.md
+++ b/content/A-Z-styleguide.md
@@ -1,11 +1,8 @@
 # A-Z writing style guide
 
-Purpose of this document: to support a consistent customer experience by defining spelling and grammar conventions used across our Springer Nature products and services.
+These guidelines help us keep our digital content consistent across our products, platforms and services – for all imprints.
 
-Intended audience: anyone writing or testing user-facing copy in SND (including designers, product managers, QA, BAs, developers, copywriters, content designers).
-
-## How to add to this guide:
-
+If there's a topic we need to cover, or an example that needs updating, talk to Gaynor Burns
 
 ## A
 ### alt text on images

--- a/content/A–Z-style-guide.md
+++ b/content/A–Z-style-guide.md
@@ -1,6 +1,6 @@
 # A-Z writing style guide
 
-These guidelines help us keep our digital content consistent across our products, platforms and services – for all imprints.
+These guidelines help us keep our digital content consistent across our products, platforms and services – for all imprints. This guide is primarily for anyone writing customer-facing copy in SN Digital.
 
 If there's a topic we need to cover, or an example that needs updating, talk to Gaynor Burns
 
@@ -329,7 +329,7 @@ For plain text emails, introduce the link with specific and active language.
 
 Example:
 <br>
-Continue with publishing your article: <https://publishing-rights.springernature.com/workflows/1234>
+Continue with publishing your article: https://publishing-rights.springernature.com/workflows/1234
 
 ### log in, login
 Login can be used but only as a noun or adjective.

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -1,11 +1,10 @@
 # Introduction
 
-Use these content guidelines when you’re writing content for Springer Nature’s digital services. This includes things like:
-- UX microcopy, like button labels, error messages, link text etc.
-- Longer form UX copy, like information about a service, terms and conditions etc.
-- Communications, like emails
+These guidelines help us keep our digital content consistent across our products, platforms and services. This includes:
 
-It does not include journals and articles, which have their own content guidelines.
-## Who is this guidance for?
+- UX microcopy like help text, form field names or error messages
+- Longer-form copy like terms and conditions or instructions
+- Emails that are part of a product experience
+- This guide is primarily for anyone writing customer-facing copy in SN Digital.
 
-We don’t have a big content design team here at Springer Nature (yet) - so it’s important that anyone who’s working on our digital products is comfortable with the basics.
+If there's a topic we need to cover, or an example that needs updating, talk to Gaynor Burns.

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -1,3 +1,11 @@
 # Introduction
 
-Please use this style guide alongside the Nature Portfolio Tone of Voice Handout. It follows the same principles as the handout but adds some more specific details and examples.
+Use these content guidelines when you’re writing content for Springer Nature’s digital services. This includes things like:
+- UX microcopy, like button labels, error messages, link text etc.
+- Longer form UX copy, like information about a service, terms and conditions etc.
+- Communications, like emails
+
+It does not include journals and articles, which have their own content guidelines.
+## Who is this guidance for?
+
+We don’t have a big content design team here at Springer Nature (yet) - so it’s important that anyone who’s working on our digital products is comfortable with the basics.


### PR DESCRIPTION
We have 

- removed per theme content documentation
- moved 'content' as a top-level url
- added an a-z style guide document as a starter

We have not

- removed the pre-existing documentation from the theme folders.